### PR TITLE
feat: Refactor to server actions and implement theme provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.4.4",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1311,7 +1312,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2385,7 +2386,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6143,6 +6144,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "15.4.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.4.4"
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { EventBusProvider } from "../providers/event-bus.provider";
+import { ThemeProvider } from "../providers/theme.provider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,7 +16,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="flex flex-col min-h-screen w-screen items-center justify-center">
-        <EventBusProvider>{children}</EventBusProvider>
+        <ThemeProvider>
+          <EventBusProvider>{children}</EventBusProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,12 @@
+"use client";
+
 import { BasicButton } from "@/components/BasicButton";
 import Link from "next/link";
+import { useThemeStore } from "../providers/theme.store";
 
 export default function Home() {
+  const { toggleTheme } = useThemeStore();
+
   return (
     <div className="flex flex-col gap-4">
       <BasicButton btnColor="red">
@@ -15,6 +20,9 @@ export default function Home() {
       </BasicButton>
       <BasicButton btnColor="yellow">
         <Link href="/counter-provider-version">Counter Provider Version</Link>
+      </BasicButton>
+      <BasicButton btnColor="purple" onClick={toggleTheme}>
+        Toggle Theme
       </BasicButton>
     </div>
   );

--- a/src/app/server-api-counter/page.tsx
+++ b/src/app/server-api-counter/page.tsx
@@ -1,52 +1,27 @@
 "use client";
 
-/**
- * TODO: LAB1
- * REFACTOR THE BELOW LOGIC AND PLEASE communicate with the next APIs via next server action instead of client communication below
- */
-
-import { FormEvent, useState } from "react";
+import { useActionState } from "react";
+import {
+  decrementCounter,
+  incrementCounter,
+} from "../../actions/counter.actions";
 
 export default function ServerApiCounterPage() {
-  const [incrementCount, setIncrementCount] = useState(0);
-  const [decrementCount, setDecrementCount] = useState(0);
-
-  const incrementHandler = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const counter = formData.get("counter") as string;
-    const response = await fetch("/api/increment", {
-      method: "POST",
-      body: JSON.stringify({ counter }),
-    });
-    const data = await response.json();
-    setIncrementCount(data.counter);
-  };
-
-  const decrementHandler = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const counter = formData.get("counter") as string;
-    const response = await fetch("/api/decrement", {
-      method: "POST",
-      body: JSON.stringify({ counter }),
-    });
-    const data = await response.json();
-    setDecrementCount(data.counter);
-  };
+  const [incrementCount, incrementAction] = useActionState(incrementCounter, 0);
+  const [decrementCount, decrementAction] = useActionState(decrementCounter, 0);
 
   return (
     <div className="flex flex-col gap-4">
       <p>Count: {incrementCount + decrementCount}</p>
       <form
-        onSubmit={incrementHandler}
+        action={incrementAction}
         className="flex flex-row items-center justify-center p-2 border border-black bg-red-200 rounded shadow-md"
       >
         <input type="hidden" name="counter" value={incrementCount} />
         <button type="submit">Increment</button>
       </form>
       <form
-        onSubmit={decrementHandler}
+        action={decrementAction}
         className="flex flex-row items-center justify-center p-2 border border-black bg-blue-200 rounded shadow-md"
       >
         <input type="hidden" name="counter" value={decrementCount} />

--- a/src/providers/theme.provider.tsx
+++ b/src/providers/theme.provider.tsx
@@ -1,4 +1,13 @@
-/**
- * TODO: LAB2
- * Implement theme provider and use event bus or zustand or whatver statemanagement lib you need to change the app theme
- */
+"use client";
+
+import { useThemeStore } from "./theme.store";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const theme = useThemeStore((state) => state.theme);
+
+  return (
+    <div className={theme} data-theme={theme}>
+      {children}
+    </div>
+  );
+}

--- a/src/providers/theme.store.ts
+++ b/src/providers/theme.store.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+
+type ThemeState = {
+  theme: "light" | "dark";
+  toggleTheme: () => void;
+};
+
+export const useThemeStore = create<ThemeState>((set) => ({
+  theme: "light",
+  toggleTheme: () =>
+    set((state) => ({ theme: state.theme === "light" ? "dark" : "light" })),
+}));


### PR DESCRIPTION
I refactored the `server-api-counter` to use server actions instead of client-side fetch calls.

I also implemented a `ThemeProvider` using Zustand for state management to allow for theme switching.